### PR TITLE
Add support for "useExplicitCheckoutFlow".

### DIFF
--- a/src/Api/Payment.php
+++ b/src/Api/Payment.php
@@ -144,7 +144,7 @@ class Payment extends ApiBase implements PaymentInterface
     /**
      * {@inheritdoc}
      */
-    public function initiatePayment($order_id, $mobile_number, $amount, $text, $callback, $fallback, $shipping = null, $consent = null, $refOrderID = null)
+    public function initiatePayment($order_id, $mobile_number, $amount, $text, $callback, $fallback, $shipping = null, $consent = null, $refOrderID = null, $useExplicitCheckoutFlow = false)
     {
         // Create Request object based on data passed to this method.
         $request = (new RequestInitiatePayment())
@@ -166,6 +166,7 @@ class Payment extends ApiBase implements PaymentInterface
                     ->setAmount($amount)
                     ->setOrderId($order_id)
                     ->setRefOrderId($refOrderID)
+                    ->setUseExplicitCheckoutFlow($useExplicitCheckoutFlow)
             );
         // Pass request object along with all data required by InitiatePayment
         // to make a call.

--- a/src/Model/Payment/Address.php
+++ b/src/Model/Payment/Address.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace SincosSoftware\Vipps\Model\Payment;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * Class ResponseRefundPayment
+ *
+ * @package Vipps\Model\Payment
+ */
+class Address
+{
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $addressLine1;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $addressLine2;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $city;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $country;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $postCode;
+
+    /**
+     * Gets addressLine1 value.
+     *
+     * @return string
+     */
+    public function getAddressLine1()
+    {
+        return $this->addressLine1;
+    }
+
+    /**
+     * Gets addressLine2 value.
+     *
+     * @return string
+     */
+    public function getAddressLine2()
+    {
+        return $this->addressLine2;
+    }
+
+    /**
+     * Gets city value.
+     *
+     * @return string
+     */
+    public function getCity()
+    {
+        return $this->city;
+    }
+
+    /**
+     * Gets country value.
+     *
+     * @return string
+     */
+    public function getCountry()
+    {
+        return $this->country;
+    }
+
+    /**
+     * Gets postCode value.
+     *
+     * @return string
+     */
+    public function getPostCode()
+    {
+        return $this->postCode;
+    }
+}

--- a/src/Model/Payment/ResponseGetPaymentDetails.php
+++ b/src/Model/Payment/ResponseGetPaymentDetails.php
@@ -25,6 +25,18 @@ class ResponseGetPaymentDetails
     protected $transactionSummary;
 
     /**
+     * @var \SincosSoftware\Vipps\Model\Payment\ShippingDetails
+     * @Serializer\Type("SincosSoftware\Vipps\Model\Payment\ShippingDetails")
+     */
+    protected $shippingDetails;
+
+    /**
+     * @var \SincosSoftware\Vipps\Model\Payment\UserDetails
+     * @Serializer\Type("SincosSoftware\Vipps\Model\Payment\UserDetails")
+     */
+    protected $userDetails;
+
+    /**
      * @var \SincosSoftware\Vipps\Model\Payment\TransactionLog[]
      * @Serializer\Type("array<SincosSoftware\Vipps\Model\Payment\TransactionLog>")
      */
@@ -48,6 +60,26 @@ class ResponseGetPaymentDetails
     public function getTransactionSummary()
     {
         return $this->transactionSummary;
+    }
+
+    /**
+     * Gets transactionSummary value.
+     *
+     * @return \SincosSoftware\Vipps\Model\Payment\ShippingDetails
+     */
+    public function getShippingDetails()
+    {
+        return $this->shippingDetails;
+    }
+
+    /**
+     * Gets transactionSummary value.
+     *
+     * @return \SincosSoftware\Vipps\Model\Payment\UserDetails
+     */
+    public function getUserDetails()
+    {
+        return $this->userDetails;
     }
 
     /**

--- a/src/Model/Payment/ShippingDetails.php
+++ b/src/Model/Payment/ShippingDetails.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace SincosSoftware\Vipps\Model\Payment;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * Class ResponseRefundPayment
+ *
+ * @package Vipps\Model\Payment
+ */
+class ShippingDetails
+{
+    /**
+     * @var \SincosSoftware\Vipps\Model\Payment\Address
+     * @Serializer\Type("SincosSoftware\Vipps\Model\Payment\Address")
+     */
+    protected $address;
+
+    /**
+     * @var float
+     * @Serializer\Type("float")
+     */
+    protected $shippingCost;
+
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $shippingMethod;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $shippingMethodId;
+
+    /**
+     * Gets address value.
+     *
+     * @return \SincosSoftware\Vipps\Model\Payment\Address
+     */
+    public function getAddress()
+    {
+        return $this->address;
+    }
+
+    /**
+     * Gets shippingCost value.
+     *
+     * @return float
+     */
+    public function getShippingCost()
+    {
+        return $this->shippingCost;
+    }
+
+    /**
+     * Gets shippingMethod value.
+     *
+     * @return string
+     */
+    public function getShippingMethod()
+    {
+        return $this->shippingMethod;
+    }
+
+    /**
+     * Gets shippingMethodId value.
+     *
+     * @return string
+     */
+    public function getShippingMethodId()
+    {
+        return $this->shippingMethodId;
+    }
+
+
+}

--- a/src/Model/Payment/Transaction.php
+++ b/src/Model/Payment/Transaction.php
@@ -72,7 +72,7 @@ class Transaction
     }
     
     /**
-     * Gets amount value.
+     * Gets useExplicitCheckoutFlow value.
      *
      * @return bool
      */

--- a/src/Model/Payment/Transaction.php
+++ b/src/Model/Payment/Transaction.php
@@ -19,6 +19,12 @@ class Transaction
     protected $orderId;
 
     /**
+     * @var boolean
+     * @Serializer\Type("boolean")
+     */
+    protected $useExplicitCheckoutFlow;
+
+    /**
      * @var string
      * @Serializer\Type("string")
      */
@@ -81,6 +87,29 @@ class Transaction
         return $this->useExplicitCheckoutFlow;
     }
     
+    /**
+     * Sets useExplicitCheckoutFlow variable.
+     *
+     * @param boolean $useExplicitCheckoutFlow
+     *
+     * @return $this
+     */
+    public function setUseExplicitCheckoutFlow($useExplicitCheckoutFlow)
+    {
+        $this->useExplicitCheckoutFlow = $useExplicitCheckoutFlow;
+        return $this;
+    }
+
+    /**
+     * Gets amount value.
+     *
+     * @return bool
+     */
+    public function getUseExplicitCheckoutFlow()
+    {
+        return $this->useExplicitCheckoutFlow;
+    }
+
     /**
      * Sets useExplicitCheckoutFlow variable.
      *

--- a/src/Model/Payment/Transaction.php
+++ b/src/Model/Payment/Transaction.php
@@ -29,7 +29,13 @@ class Transaction
      * @Serializer\Type("integer")
      */
     protected $amount;
-
+    
+    /**
+     * @var bool
+     * @Serializer\Type("boolean")
+     */
+    protected $useExplicitCheckoutFlow;
+    
     /**
      * @var string
      * @Serializer\Type("string")
@@ -62,6 +68,29 @@ class Transaction
     public function setAmount($amount)
     {
         $this->amount = $amount;
+        return $this;
+    }
+    
+    /**
+     * Gets amount value.
+     *
+     * @return bool
+     */
+    public function getUseExplicitCheckoutFlow()
+    {
+        return $this->useExplicitCheckoutFlow;
+    }
+    
+    /**
+     * Sets amount variable.
+     *
+     * @param int $amount
+     *
+     * @return $this
+     */
+    public function setUseExplicitCheckoutFlow($useExplicitCheckoutFlow)
+    {
+        $this->useExplicitCheckoutFlow = $useExplicitCheckoutFlow;
         return $this;
     }
 

--- a/src/Model/Payment/Transaction.php
+++ b/src/Model/Payment/Transaction.php
@@ -82,9 +82,9 @@ class Transaction
     }
     
     /**
-     * Sets amount variable.
+     * Sets useExplicitCheckoutFlow variable.
      *
-     * @param int $amount
+     * @param boolean $useExplicitCheckoutFlow
      *
      * @return $this
      */

--- a/src/Model/Payment/Transaction.php
+++ b/src/Model/Payment/Transaction.php
@@ -37,12 +37,6 @@ class Transaction
     protected $amount;
     
     /**
-     * @var bool
-     * @Serializer\Type("boolean")
-     */
-    protected $useExplicitCheckoutFlow;
-    
-    /**
      * @var string
      * @Serializer\Type("string")
      */
@@ -87,29 +81,6 @@ class Transaction
         return $this->useExplicitCheckoutFlow;
     }
     
-    /**
-     * Sets useExplicitCheckoutFlow variable.
-     *
-     * @param boolean $useExplicitCheckoutFlow
-     *
-     * @return $this
-     */
-    public function setUseExplicitCheckoutFlow($useExplicitCheckoutFlow)
-    {
-        $this->useExplicitCheckoutFlow = $useExplicitCheckoutFlow;
-        return $this;
-    }
-
-    /**
-     * Gets amount value.
-     *
-     * @return bool
-     */
-    public function getUseExplicitCheckoutFlow()
-    {
-        return $this->useExplicitCheckoutFlow;
-    }
-
     /**
      * Sets useExplicitCheckoutFlow variable.
      *

--- a/src/Model/Payment/UserDetails.php
+++ b/src/Model/Payment/UserDetails.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SincosSoftware\Vipps\Model\Payment;
+
+use JMS\Serializer\Annotation as Serializer;
+
+/**
+ * Class ResponseRefundPayment
+ *
+ * @package Vipps\Model\Payment
+ */
+class UserDetails
+{
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $bankIdVerified;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $email;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $firstName;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $lastName;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $mobileNumber;
+
+    /**
+     * @var string
+     * @Serializer\Type("string")
+     */
+    protected $userId;
+
+    /**
+     * @return string
+     */
+    public function getBankIdVerified()
+    {
+        return $this->bankIdVerified;
+    }
+
+    /**
+     * @return string
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFirstName()
+    {
+        return $this->firstName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getLastName()
+    {
+        return $this->lastName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMobileNumber()
+    {
+        return $this->mobileNumber;
+    }
+
+}


### PR DESCRIPTION
@rogerlysberg Will be required for v1's implementation of vipps-ecom-express.

As the title suggests, adds support for the explicit checkout flow (where the user has to confirm what address the order should be shipped to), disabled by default, so will not affect existing implementation(s).

Also expands on the `ResponseGetPaymentDetails` dto with more sub objects, enabling us to get things like shippingmethod details, and general information about the customer.